### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -1,3 +1,3 @@
 idf_component_register(
-        SRCS "sco_demo_util.c" "microphone.c" "speaker.c" "hfp_hf_demo.c" "main.c" "soc_demo_util.c"
+        SRCS "sco_demo_util.c" "microphone.c" "speaker.c" "hfp_hf_demo.c" "main.c"
         INCLUDE_DIRS "${CMAKE_CURRENT_BINARY_DIR}")


### PR DESCRIPTION
File "soc_demo_util.c" referenced in main/CMakeList.txt does not appear to exist, and will fail build. Appears to be a redundant typo for "sco_demo_util.c"